### PR TITLE
Specify requirements from repo instead of PyPI for some 3rd party apps

### DIFF
--- a/requirements.tests/edc.txt
+++ b/requirements.tests/edc.txt
@@ -11,7 +11,6 @@ django-celery-results
 django-collect-offline
 django-collect-offline-files
 django-crypto-fields
-django-defender
 django-multisite
 django-revision
 django_extensions
@@ -69,3 +68,7 @@ edc-transfer
 edc-utils
 edc-visit-schedule
 edc-visit-tracking
+git+https://github.com/erikvw/django-import-export@get_export_admin_action
+git+https://github.com/jazzband/django-defender@master
+git+https://github.com/yprez/django-logentry-admin@master
+


### PR DESCRIPTION
More closely aligns the `edc.txt` file with the `requirements.txt` file by also using the latest repo versions (instead latest PyPI releases) for some 3rd party apps, allowing access to bugfixes/features that are still pending release.  